### PR TITLE
CalculationHelper 배포

### DIFF
--- a/contracts/misc/CalculationHelper.sol
+++ b/contracts/misc/CalculationHelper.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity >=0.8.0;
+
+import "../interfaces/IConcentratedLiquidityPool.sol";
+import "../libraries/DyDxMath.sol";
+import "../libraries/TickMath.sol";
+
+contract CalculationHelper {
+
+    function getAmountsForLiquidity(
+        address pool,
+        int24 lower,
+        int24 upper,
+        uint256 liquidityAmount
+    ) external view returns (uint128 token0amount, uint128 token1amount) {
+        return
+        DyDxMath.getAmountsForLiquidity(
+            uint256(TickMath.getSqrtRatioAtTick(lower)),
+            uint256(TickMath.getSqrtRatioAtTick(upper)),
+            IConcentratedLiquidityPool(pool).price(),
+            liquidityAmount,
+            true
+        );
+    }
+
+    function getLiquidityForAmounts(
+        address pool,
+        int24 lower,
+        int24 upper,
+        uint256 amount0,
+        uint256 amount1
+    ) external view returns (uint256 liquidity) {
+        return
+            DyDxMath.getLiquidityForAmounts(
+                uint256(TickMath.getSqrtRatioAtTick(lower)),
+                uint256(TickMath.getSqrtRatioAtTick(upper)),
+                IConcentratedLiquidityPool(pool).price(),
+                amount1,
+                amount0
+            );
+    }
+
+    /// @notice Calculates sqrt(1.0001^tick) * 2^96.
+    function getPriceAtTick(int24 tick) external view returns (uint160) {
+        return TickMath.getSqrtRatioAtTick(tick);
+    }
+
+    /// @notice Calculates the greatest tick value such that getRatioAtTick(tick) <= ratio.
+    /// @param price Sqrt of price aka. √(token1/token0), multiplied by 2 ^ 96.
+    function getTickAtSqrtRatio(uint160 price) external view returns (int24) {
+        return TickMath.getTickAtSqrtRatio(price);
+    }
+}

--- a/deploy/CalculationHelper.ts
+++ b/deploy/CalculationHelper.ts
@@ -1,0 +1,24 @@
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { waitConfirmations } from "./utils";
+import { BigNumber } from "ethers";
+
+const deployFunction: DeployFunction = async function ({
+  deployments,
+  getNamedAccounts,
+}: HardhatRuntimeEnvironment) {
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+
+  await deploy("CalculationHelper", {
+    from: deployer,
+    deterministicDeployment: false,
+    waitConfirmations: await waitConfirmations(),
+    log: true,
+    gasPrice: BigNumber.from("250000000000"),
+  });
+};
+
+export default deployFunction;
+
+deployFunction.tags = ["CalculationHelper", "deploy"];

--- a/deployments/abis/CalculationHelper.json
+++ b/deployments/abis/CalculationHelper.json
@@ -1,0 +1,128 @@
+[
+  {
+    "inputs": [],
+    "name": "PriceOutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TickOutOfBounds",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "int24",
+        "name": "lower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "upper",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidityAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountsForLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "token0amount",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "token1amount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "int24",
+        "name": "lower",
+        "type": "int24"
+      },
+      {
+        "internalType": "int24",
+        "name": "upper",
+        "type": "int24"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "getLiquidityForAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int24",
+        "name": "tick",
+        "type": "int24"
+      }
+    ],
+    "name": "getPriceAtTick",
+    "outputs": [
+      {
+        "internalType": "uint160",
+        "name": "",
+        "type": "uint160"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint160",
+        "name": "price",
+        "type": "uint160"
+      }
+    ],
+    "name": "getTickAtSqrtRatio",
+    "outputs": [
+      {
+        "internalType": "int24",
+        "name": "",
+        "type": "int24"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
* cypress : `0x76009890780Bf8345f5847614684C5fFa2AAA067`

#### 1. 주어진 가격범위에 token0의 갯수(amount0)와 token1의 갯수(amount1)을 넣었을 때 받을 수 있는 유동성 크기
````solidity
    function getLiquidityForAmounts(
        address pool,
        int24 lower,
        int24 upper,
        uint256 amount0,
        uint256 amount1
    ) external view returns (uint256 liquidity);
````

#### 2. 주어진 가격범위와 유동성에 대한 토큰 갯수
````solidity
    function getAmountsForLiquidity(
        address pool,
        int24 lower,
        int24 upper,
        uint256 liquidityAmount
    ) external view returns (uint128 token0amount, uint128 token1amount);
````

#### USDT/USDC
* lower : -4 (0.0006)
* upper : 6  (1.0006)

#### USDT/DAI
* lower : -276,328 (0.999603)
* upper: -276,318 (1.0006)